### PR TITLE
pyproject.toml: Remove upper bound on attrs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 requires-python = "~=3.6"
 requires = [
-    "attrs >= 19.3, <21",
+    "attrs >= 19.3",
     "more-itertools >=8.0.2, <9",
 ]
 


### PR DESCRIPTION
Remove the upper bound restriction on attrs package verion, and keep
the mnimum version requirement.

This allows dependents and packagers to not break when building
software that depends on this library.

I've done this solely for the "attrs" package and not for
"more-itertools" mainly because "attrs" is now at 21.2.0 (outside the
upper version constraint) while "more-itertools" is still at 8.8.0
(within the upper version constraint), but eventually the same will
probably happen to "more-itertools".