### PR TITLE
Bump version to prepare for release

### DIFF
--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -16,7 +16,7 @@ import attr
 import more_itertools
 
 __all__ = ["__version__", "Checker"]
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 _ERROR = Tuple[int, int, str, None]
 


### PR DESCRIPTION
As requested in https://github.com/keisheiled/flake8-implicit-str-concat/issues/29, as the attrs fix in https://github.com/keisheiled/flake8-implicit-str-concat/pull/28 would help people.

Would be nice to release with the Python 3.10 Trove classifier too: https://github.com/keisheiled/flake8-implicit-str-concat/pull/30.