### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,21 +21,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{
-            hashFiles('**/pyproject.toml')}}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v2.14.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
     rev: 21.5b0
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.9.1

--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -6,8 +6,6 @@ introduced by Black.
 Forbid all explicitly concatenated strings, in favour of implicit concatenation.
 """
 
-from __future__ import generator_stop
-
 import ast
 import tokenize
 from typing import Iterable, List, Tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core >=2,<3"]
 build-backend = "flit_core.buildapi"
 
 [tool.black]
-target_version = ["py36"]
+target_version = ["py37"]
 
 [tool.flit.metadata]
 module = "flake8_implicit_str_concat"
@@ -20,7 +20,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -29,7 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = "~=3.6"
+requires-python = "~=3.7"
 requires = [
     "attrs >= 19.3",
     "more-itertools >=8.0.2, <9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{36, 37, 38}
+    py{37, 38, 39, 310}
     mypy
 isolated_build = True
 


### PR DESCRIPTION
Python 3.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

https://endoflife.date/python

Also use https://github.com/actions/setup-python 's caching to simplify CI config.